### PR TITLE
Stops admin log messages during intialization

### DIFF
--- a/code/game/objects/items/debug_items.dm
+++ b/code/game/objects/items/debug_items.dm
@@ -37,7 +37,8 @@
 	. = ..()
 	if(!(istype(get_area(src), /area/tdome/arena)))
 		visible_message("<span class='warning'>...Just kidding. [src] snaps in two.</span>")
-		message_admins("An omnitool was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
+		if(Master.current_runlevel) // If the game hasn't loaded yet, don't display this message
+			message_admins("An omnitool was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
 		qdel(src)
 
 /obj/item/debug/omnitool/examine()

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -37,7 +37,8 @@
 	. = ..()
 	if(!(istype(get_area(src), /area/tdome/arena)))
 		visible_message("<span class='warning'>...Just kidding. [src] snaps in two.</span>")
-		message_admins("A multitool was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
+		if(Master.current_runlevel) // If the game hasn't loaded yet, don't display this message
+			message_admins("A multitool was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
 		qdel(src)
 
 /obj/item/multitool/examine(mob/user)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -165,7 +165,8 @@
 	. = ..()
 	if(!(istype(get_area(src), /area/tdome/arena)))
 		visible_message("<span class='warning'>...Just kidding. [src] snaps in two.</span>")
-		message_admins("A spear was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
+		if(Master.current_runlevel) // If the game hasn't loaded yet, don't display this message
+			message_admins("A spear was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
 		qdel(src)
 
 /*

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -26,7 +26,8 @@
 	. = ..()
 	if(!(istype(get_area(src), /area/tdome/arena)))
 		visible_message("<span class='warning'>...Just kidding. [src] snaps in two.</span>")
-		message_admins("A crowbar was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
+		if(Master.current_runlevel) // If the game hasn't loaded yet, don't display this message
+			message_admins("A crowbar was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
 		qdel(src)
 
 /obj/item/crowbar/suicide_act(mob/user)

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -41,7 +41,8 @@
 	. = ..()
 	if(!(istype(get_area(src), /area/tdome/arena)))
 		visible_message("<span class='warning'>...Just kidding. [src] snaps in two.</span>")
-		message_admins("A screwdriver was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
+		if(Master.current_runlevel) // If the game hasn't loaded yet, don't display this message
+			message_admins("A screwdriver was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
 		qdel(src)
 
 /obj/item/screwdriver/suicide_act(mob/user)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -50,7 +50,8 @@
 	update_icon()
 	if(!(istype(get_area(src), /area/tdome/arena)))
 		visible_message("<span class='warning'>...Just kidding. [src] snaps in two.</span>")
-		message_admins("A welder was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
+		if(Master.current_runlevel) // If the game hasn't loaded yet, don't display this message
+			message_admins("A welder was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
 		qdel(src)
 
 /obj/item/weldingtool/ComponentInitialize()

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -44,7 +44,8 @@
 		update_icon()
 	if(!(istype(get_area(src), /area/tdome/arena)))
 		visible_message("<span class='warning'>...Just kidding. [src] snaps in two.</span>")
-		message_admins("A wirecutter was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
+		if(Master.current_runlevel) // If the game hasn't loaded yet, don't display this message
+			message_admins("A wirecutter was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
 		qdel(src)
 
 /obj/item/wirecutters/update_overlays()

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -26,7 +26,8 @@
 	. = ..()
 	if(!(istype(get_area(src), /area/tdome/arena)))
 		visible_message("<span class='warning'>...Just kidding. [src] snaps in two.</span>")
-		message_admins("A wrench was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
+		if(Master.current_runlevel) // If the game hasn't loaded yet, don't display this message
+			message_admins("A wrench was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
 		qdel(src)
 
 /obj/item/wrench/suicide_act(mob/user)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -679,7 +679,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	if(!(istype(get_area(src), /area/tdome/arena)))
 		visible_message("<span class='warning'>...Just kidding. [src] snaps in two.</span>")
-		message_admins("A baseball bat was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
+		if(Master.current_runlevel) // If the game hasn't loaded yet, don't display this message
+			message_admins("A baseball bat was crafted out of the arena at [ADMIN_VERBOSEJMP(src.loc)].")
 		qdel(src)
 
 /obj/item/melee/flyswatter


### PR DESCRIPTION
It stops the initialization messages that were spamming up the chat from Centcomm and the holodeck, but if you spawn tools manually before the game starts it'll still show the message 