### PR TITLE
Ancient toolbox in table arena fix

### DIFF
--- a/config/arenas/tables.dmm
+++ b/config/arenas/tables.dmm
@@ -22,7 +22,7 @@
 /area/tdome/arena)
 "e" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical/old/clean,
+/obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel,
 /area/tdome/arena)
 "f" = (


### PR DESCRIPTION
Ancient toolbox has 7 more force than normal ones, big no-no.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the ancient toolbox into a normal old toolbox


## Changelog
:cl:
Tweak: Makes the ancient toolbox old
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
