### PR TITLE
Adds tablets for viewing cameras to everyones boxes

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1293,6 +1293,8 @@
 	new /obj/item/cowbell(src)
 	new /obj/item/stack/arcadeticket(src)
 	new /obj/item/teleportation_scroll/no_smoke(src)
+	new /obj/item/modular_computer/tablet/event_viewer(src)
+
 /obj/item/paper/donator
 	name = "paper- 'Letter to all donators'"
 	info = "<h1>Thank you so much for donating!</h1><p>We couldn't have done this event without you. I'm so glad that /tg/ has been able to come together to do something wonderful and I'm even more glad that you've decided to be a part of it. This is truly a great thing and I appreciate your donation.</p><p>This is my second year doing this and it's been an amazing ride. I hope that everything goes well in this event and I'm really glad to have you join us. It's been my pleasure to faciliate and host these events with amazing mappers and people inside of /tg/, including yourself.</p><p>Thank you again, </br> <i>CitrusGender</i></p>"

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -138,3 +138,8 @@
 /obj/item/modular_computer/tablet/integrated/syndicate/Initialize()
 	. = ..()
 	borgo.lamp_color = COLOR_RED //Syndicate likes it red
+
+/obj/item/modular_computer/tablet/event_viewer
+	name = "Limited Edition Event Tablet"
+	desc = "A tablet computer that includes a program for viewing cameras."
+

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -75,3 +75,10 @@
 	install_component(new /obj/item/computer_hardware/hard_drive/small/integrated)
 	install_component(new /obj/item/computer_hardware/recharger/cyborg)
 	install_component(new /obj/item/computer_hardware/network_card/integrated)
+
+/obj/item/modular_computer/tablet/event_viewer/Initialize()
+	. = ..()
+	install_component(new /obj/item/computer_hardware/processor_unit/small)
+	install_component(new /obj/item/computer_hardware/hard_drive/small/event)
+	install_component(new /obj/item/computer_hardware/network_card)
+	install_component(new /obj/item/computer_hardware/recharger/lambda)

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -193,3 +193,14 @@
 		if(tempnetwork.len)
 			camlist["[cam.c_tag]"] = cam
 	return camlist
+
+/datum/computer_file/program/secureye/eventviewer
+	filename = "toolboxtv"
+	filedesc = "ToolboxTV"
+	ui_header = null
+	program_icon_state = "generic"
+	extended_desc = "This program allows access to cameras at certain sporting events."
+	usage_flags = PROGRAM_ALL
+	requires_ntnet = FALSE
+	size = 1
+	program_icon = "toolbox"

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -164,6 +164,7 @@
 	store_file(new /datum/computer_file/program/computerconfig(src)) 	// Computer configuration utility, allows hardware control and displays more info than status bar
 	store_file(new /datum/computer_file/program/filemanager(src))		// File manager, allows text editor functions and basic file manipulation.
 	store_file(new /datum/computer_file/program/robotact(src))
+	store_file(new/datum/computer_file/program/secureye/eventviewer(src))
 
 
 // Syndicate variant - very slight better
@@ -193,8 +194,9 @@
 	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/computer_hardware/hard_drive/small/event
-	max_capacity = 1024
+	max_capacity = 64
 
 /obj/item/computer_hardware/hard_drive/small/event/install_default_programs()
-	. = ..()
+	store_file(new /datum/computer_file/program/computerconfig(src))
+	store_file(new /datum/computer_file/program/filemanager(src))
 	store_file(new/datum/computer_file/program/secureye/eventviewer(src))

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -191,3 +191,10 @@
 	max_capacity = 32
 	icon_state = "ssd_micro"
 	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/computer_hardware/hard_drive/small/event
+	max_capacity = 1024
+
+/obj/item/computer_hardware/hard_drive/small/event/install_default_programs()
+	. = ..()
+	store_file(new/datum/computer_file/program/secureye/eventviewer(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a tablet subtype that comes with a tablet-friendly version of SecurEye called ToolboxTV. These tablets have an infinite power source.

Adds these tablets to the starting boxes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Binoculars LV 2
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

~~By the by I still need to test this so hang on.~~ All good